### PR TITLE
add new just command, gitpod and fix typos

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,9 @@
+tasks:
+  - init: |
+      brew install yq mdbook just watchexec
+      cargo install --git https://github.com/chevdor/tera-cli
+  - command: just render && just serve
+
+ports:
+  - port: 3000
+    onOpen: open-preview

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ WARNING: THIS REPO IS WIP AND THE INFORMATION MAYBE NOT YET BE ACCURATE.
 - [`tera`](https://github.com/chevdor/tera-cli)
 - [`mdbook`](https://github.com/rust-lang/mdBook)
 - [`just`](https://github.com/casey/just)
+- [`watchexec`](https://github.com/watchexec/watchexec)
 
 ## Folders
 
@@ -25,17 +26,19 @@ WARNING: THIS REPO IS WIP AND THE INFORMATION MAYBE NOT YET BE ACCURATE.
 
 ```
 
-
 ## Usage
 
 You can refresh the book using:
 
      just render
 
-If you want to serve a page showing the result, in another termminal, you may run:
+You can automatically watch the changes by using:
+
+     just watch
+
+If you want to serve a page showing the result, in another terminal, you may run:
 
      just serve
-
 
 ## Editing content
 
@@ -43,16 +46,17 @@ The **only** content that needs editing are the `yaml` files under `chain_info`.
 
 ## Editing templates
 
-You can find the few templates using:
+You can find template files using:
 
      find . -name "*.tera"
 
 There are 2 important templates:
+
 - `templates/one.md.tera`: This template is used to convert the input `yaml` data into a markdown file per chain
 - `templates/summary.md.tera`: This template is used to dynamically generate the summary of the book, it takes care of organising parachains under their `parent` relaychain
 
 ## Reference file
 
-During the generate, all the data is aggregated into a json file containing the information about all the chains.
+During the generation, all the data is aggregated into a `json` file containing the information about all the chains.
 
 This file can be found at https://paritytech.github.io/polkadot_network_directory/chains.json

--- a/justfile
+++ b/justfile
@@ -38,6 +38,10 @@ serve:
 	open http://localhost:3000/
 	mdbook serve
 
+# watch the files under the chain_info and render them
+watch: 
+	watchexec -w chain_info -- just render
+
 # Cleanup generated files
 clean:
 	rm -rf directory/book

--- a/templates/one.md.tera
+++ b/templates/one.md.tera
@@ -40,7 +40,7 @@
 | token    | {{specs.token | default(value="n/a")}} |
 | ED    | {{specs.ed | default(value="n/a")}} units |
 {%- if chain.parent %}
-| consensus    | Same than `{{ chain.parent }}` |
+| consensus    | Same as `{{ chain.parent }}` |
 {% else -%}
 {% if chain.consensus %}
 | consensus    | {{ chain.consensus }} |


### PR DESCRIPTION
Additions are: 

- `just watch` -- watcher for the `chain_info` directory
- add `.gitpod.yml` - the spirit of the online IDE; this will also install all needed components
- update `README.md` to reflect new dep (`watchexec`) and fix a few typos